### PR TITLE
Implement version of the tools

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -8,9 +8,20 @@ from .container.docker_manager import DockerManager
 from .logs.log_analyzer import LogAnalyzer
 from .infrastructure.provisioner import InfrastructureProvisioner
 from .remote.ssh_manager import SSHManager
+from .version import __version__
 
 app = typer.Typer(help="OpsZen - A comprehensive toolkit for system monitoring, container management, and more.")
 console = Console()
+
+def version_callback(value: bool):
+    if value:
+        console.print(f"OpsZen version: {__version__}")
+        raise typer.Exit()
+
+@app.callback(invoke_without_command=True)
+def main(version: Optional[bool] = typer.Option(None, "--version", "-v", callback=version_callback, is_eager=True, help="Show the version and exit.")):
+    """OpsZen - A comprehensive toolkit for system monitoring, container management, and more."""
+    pass
 
 # Create sub-applications for each module
 monitor_app = typer.Typer(help="System monitoring commands")

--- a/src/version.py
+++ b/src/version.py
@@ -1,0 +1,3 @@
+"""Version information for OpsZen."""
+
+__version__ = "0.1.0"


### PR DESCRIPTION
## Summary by Sourcery

Add version management to CLI by introducing a version module and a --version flag that prints the current version.

New Features:
- Introduce a version.py module defining the application version.
- Add a --version/-v option to the main CLI to display the OpsZen version and exit.