### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ To set up the development environment:
 
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/opszen.git
-cd opszen
+git clone https://github.com/TianaNanta/OpsZen.git
+cd OpsZen
 
 # Create a virtual environment and install dependencies
 uv venv


### PR DESCRIPTION
## Summary by Sourcery

Update the repository clone instructions in the README to use the correct GitHub URL and directory name.

Documentation:
- Use the TianaNanta/OpsZen repository URL in git clone instructions
- Correct the example directory name from opszen to OpsZen in the setup steps